### PR TITLE
Fixing openal audio duplicating sourceids (#7095)

### DIFF
--- a/MonoGame.Framework/Platform/Audio/DynamicSoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/DynamicSoundEffectInstance.OpenAL.cs
@@ -106,14 +106,18 @@ namespace Microsoft.Xna.Framework.Audio
         {
             // Stop the source and bind null buffer so that it can be recycled
             AL.GetError();
-            if (AL.IsSource(SourceId))
+
+            lock (sourceMutex)
             {
-                AL.SourceStop(SourceId);
-                AL.Source(SourceId, ALSourcei.Buffer, 0);
-                ALHelper.CheckError("Failed to stop the source.");
-                controller.RecycleSource(SourceId);
+                if (HasSourceId && AL.IsSource(SourceId))
+                {
+                    AL.SourceStop(SourceId);
+                    AL.Source(SourceId, ALSourcei.Buffer, 0);
+                    ALHelper.CheckError("Failed to stop the source.");
+                    controller.FreeSource(this);
+                }
             }
-            
+
             if (disposing)
             {
                 while (_queuedBuffers.Count > 0)

--- a/MonoGame.Framework/Platform/Media/Song.NVorbis.cs
+++ b/MonoGame.Framework/Platform/Media/Song.NVorbis.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Xna.Framework.Media
     {
         private OggStream stream;
         private float _volume = 1f;
+        private readonly object _sourceMutex = new object();
 
         private void PlatformInitialize(string fileName)
         {
@@ -34,11 +35,14 @@ namespace Microsoft.Xna.Framework.Media
 		
         void PlatformDispose(bool disposing)
         {
-            if (stream == null)
-                return;
+            lock (_sourceMutex)
+            {
+                if (stream == null)
+                    return;
 
-            stream.Dispose();
-            stream = null;
+                stream.Dispose();
+                stream = null;
+            }
         }
 
         internal void Play(TimeSpan? startPosition)


### PR DESCRIPTION
* Use FreeSource() instead of RecycleSource() so HasSourceId will be set to false. Also check for HasSourceId before FreeSource() so we aren't recycling the same source ids multiple times.

* Prevents recycling duplicate openAl source ids by locking around recycling functions